### PR TITLE
Conceptualize MCP via gRPC in agent definitions

### DIFF
--- a/Eddy.json
+++ b/Eddy.json
@@ -217,8 +217,36 @@
       {
         "user": "Eddy",
         "content": {
-          "text": "Alright, I've sent the task request to Jules with your problem description. He should get back to us with an analysis or a solution. I'll let you know as soon as I hear from him.",
-          "thought": "Sent TASK_REQUEST to Jules. Message ID: [unique_message_id_for_task_request]. Waiting for Jules's TASK_ACCEPT and then INFORM_RESULT."
+          "text": "Alright, I'm (conceptually) sending the task request to Jules via a gRPC call. He should receive it and process it. I'll await his response. I'll let you know as soon as I (conceptually) hear back from him.",
+          "thought": "Constructing MCP TASK_REQUEST for Jules (as a conceptual Protobuf object). Simulating a gRPC call to 'AgentCommunicationService.SendMessage' with this message, targeting Jules. I will then conceptually await a response (TASK_ACCEPT and INFORM_RESULT) which would arrive via a similar gRPC mechanism or a predefined callback/reply channel in a full implementation.",
+          "simulated_grpc_call": {
+            "service": "AgentCommunicationService",
+            "method": "SendMessage",
+            "target_agent_id": "Jules",
+            "request_message": { // JSON representation of the conceptual Protobuf MCPMessage
+              "mcp_version": "0.1.0",
+              "message_id": "msg_eddy_jules_grpc_req_001",
+              "performative": "TASK_REQUEST", // Corresponds to Performative enum value
+              "sender": { "agent_id": "Eddy" },
+              "receiver": { "agent_id": "Jules" },
+              "reply_with": "eddy_task_debug_grpc_001",
+              "language": "application/json", // Language of the Any.payload's packed message if it were JSON
+              "ontology": "elizaos:ontology:code/python/debug_request",
+              "timestamp": "YYYY-MM-DDTHH:MM:SSZ", // google.protobuf.Timestamp string representation
+              "payload": { // This represents the google.protobuf.Any field, type URL would point to TaskRequestPayload
+                "@type": "type.googleapis.com/elizaos.mcp.TaskRequestPayload", // Example type URL
+                "task_type": "debug_code",
+                "task_description": "User {{user1}} needs help with an IndexError in a Python script for parsing log files.",
+                "task_parameters": {
+                  "code_to_debug": "User has not provided code yet, but mentioned it's a Python script for parsing log files and is experiencing an IndexError.",
+                  "programming_language": "python",
+                  "error_log": "IndexError reported by user.",
+                  "desired_outcome": "Identify and fix the bug, or provide analysis if not fixable. Jules should request the actual code and traceback from the user via Eddy."
+                },
+                "priority": "medium"
+              }
+            }
+          }
         }
       }
     ]

--- a/Jules.json
+++ b/Jules.json
@@ -70,25 +70,26 @@
       {
         "user": "Eddy",
         "content": {
-          "text": "MCP Message (Simulated Reception)",
-          "mcp_message_content": {
+          "text": "(Conceptual) Simulating Jules receiving a TASK_REQUEST from Eddy via an incoming gRPC call.",
+          "triggering_grpc_message": { // This represents the MCPMessage Jules "receives" via gRPC
             "mcp_version": "0.1.0",
-            "message_id": "msg_eddy_to_jules_001",
+            "message_id": "msg_eddy_jules_grpc_req_001",
             "performative": "TASK_REQUEST",
             "sender": { "agent_id": "Eddy" },
             "receiver": { "agent_id": "Jules" },
-            "reply_with": "task_reply_001",
+            "reply_with": "eddy_task_debug_grpc_001",
             "language": "application/json",
             "ontology": "elizaos:ontology:code/python/debug_request",
-            "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
-            "payload": {
+            "timestamp": "YYYY-MM-DDTHH:MM:SSZ", // google.protobuf.Timestamp string representation
+            "payload": { // This represents the google.protobuf.Any field
+              "@type": "type.googleapis.com/elizaos.mcp.TaskRequestPayload",
               "task_type": "debug_code",
               "task_description": "User {{user1}} needs help with an IndexError in a Python script for parsing log files.",
               "task_parameters": {
-                "code_to_debug": "User has not provided code yet, but mentioned it's a Python script for parsing log files.",
+                "code_to_debug": "User has not provided code yet, but mentioned it's a Python script for parsing log files and is experiencing an IndexError.",
                 "programming_language": "python",
-                "error_log": "IndexError",
-                "desired_outcome": "Identify and fix the bug, or provide analysis."
+                "error_log": "IndexError reported by user.",
+                "desired_outcome": "Identify and fix the bug, or provide analysis if not fixable. Jules should request the actual code and traceback from the user via Eddy."
               },
               "priority": "medium"
             }
@@ -98,23 +99,29 @@
       {
         "user": "Jules",
         "content": {
-          "text": "MCP Message (Simulated Sending of TASK_ACCEPT)",
+          "text": "Okay, I've (conceptually) received the debugging task via gRPC. I will accept this task and (conceptually) send a TASK_ACCEPT message back to Eddy using a gRPC call.",
           "actions": ["EXECUTE_DELEGATED_CODING_TASK"],
-          "thought": "Received TASK_REQUEST msg_eddy_to_jules_001 from Eddy. The task is to debug a Python IndexError. I will accept the task and then begin analysis. I need to ask the user (via Eddy) for the code and traceback.",
-          "mcp_message_content": {
-            "mcp_version": "0.1.0",
-            "message_id": "msg_jules_to_eddy_002",
-            "performative": "TASK_ACCEPT",
-            "sender": { "agent_id": "Jules" },
-            "receiver": { "agent_id": "Eddy" },
-            "in_reply_to": "msg_eddy_to_jules_001",
-            "language": "application/json",
-            "ontology": "elizaos:ontology:general/task_acceptance",
-            "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
-            "payload": {
-              "status": "accepted",
-              "task_id_assigned": "jules_task_debug_001",
-              "comments": "Beginning analysis of Python IndexError. Will require code and traceback from user."
+          "thought": "Conceptually received gRPC message 'msg_eddy_jules_grpc_req_001' from Eddy containing a TASK_REQUEST. The task is to debug a Python IndexError. I will construct an MCP TASK_ACCEPT message (as a conceptual Protobuf object) and simulate sending it back to Eddy via 'AgentCommunicationService.SendMessage'. Then, I'll (conceptually) begin analysis.",
+          "simulated_grpc_call": {
+            "service": "AgentCommunicationService",
+            "method": "SendMessage",
+            "target_agent_id": "Eddy",
+            "request_message": { // JSON representation of the conceptual Protobuf MCPMessage for TASK_ACCEPT
+              "mcp_version": "0.1.0",
+              "message_id": "msg_jules_eddy_grpc_accept_001",
+              "performative": "TASK_ACCEPT",
+              "sender": { "agent_id": "Jules" },
+              "receiver": { "agent_id": "Eddy" },
+              "in_reply_to": "msg_eddy_jules_grpc_req_001", // Referencing Eddy's TASK_REQUEST
+              "language": "application/json",
+              "ontology": "elizaos:ontology:general/task_acceptance",
+              "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
+              "payload": {
+                "@type": "type.googleapis.com/elizaos.mcp.TaskAcceptPayload",
+                "status": "accepted",
+                "task_id_assigned": "jules_grpc_task_001",
+                "comments": "Task accepted via gRPC. Will begin analysis of the Python IndexError. Please request the specific code snippet and full error traceback from the user via Eddy."
+              }
             }
           }
         }
@@ -122,26 +129,32 @@
       {
         "user": "Jules",
         "content": {
-          "text": "MCP Message (Simulated Sending of INFORM_RESULT)",
-          "thought": "Analysis complete for jules_task_debug_001. The IndexError is likely caused by attempting to access a list element with an out-of-range index. I will provide initial guidance and request more information.",
-          "mcp_message_content": {
-            "mcp_version": "0.1.0",
-            "message_id": "msg_jules_to_eddy_003",
-            "performative": "INFORM_RESULT",
-            "sender": { "agent_id": "Jules" },
-            "receiver": { "agent_id": "Eddy" },
-            "in_reply_to": "msg_eddy_to_jules_001", // Responding to the original task request
-            "language": "application/json",
-            "ontology": "elizaos:ontology:code/python/debug_analysis", // Could be solution_provided if fixed
-            "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
-            "payload": {
-              "task_status": "partial_success", // Analysis provided, but code/fix pending user input
-              "result_summary": "Initial analysis of Python IndexError complete. Likely out-of-bounds list access.",
-              "result_details": {
-                "analysis": "IndexError in Python scripts, especially for log parsing, often occurs when trying to access list elements using an index that is outside the valid range (e.g., accessing list[i] when i is >= len(list) or list is empty). This can happen if log lines are split incorrectly, or if assumptions about the number of fields per log line are not met. The user should verify list lengths before access, check loop conditions, and ensure any string splitting or parsing logic correctly handles various log line formats.",
-                "request_for_user_via_eddy": "To provide a specific fix, please ask the user to provide the Python code snippet where the IndexError occurs, along with the full error traceback."
-              },
-              "artifacts": []
+          "text": "Initial analysis complete. (Conceptually) sending an INFORM_RESULT to Eddy via gRPC with findings and a request for more details.",
+          "thought": "Simulated execution of task 'jules_grpc_task_001'. The IndexError is common in Python. Without specific code, I'll provide general guidance. I will now construct an MCP INFORM_RESULT message (as a conceptual Protobuf object) and simulate sending it to Eddy via 'AgentCommunicationService.SendMessage'.",
+          "simulated_grpc_call": {
+            "service": "AgentCommunicationService",
+            "method": "SendMessage",
+            "target_agent_id": "Eddy",
+            "request_message": { // JSON representation of the conceptual Protobuf MCPMessage for INFORM_RESULT
+              "mcp_version": "0.1.0",
+              "message_id": "msg_jules_eddy_grpc_inform_002",
+              "performative": "INFORM_RESULT",
+              "sender": { "agent_id": "Jules" },
+              "receiver": { "agent_id": "Eddy" },
+              "in_reply_to": "msg_eddy_jules_grpc_req_001", // Referencing Eddy's original TASK_REQUEST
+              "language": "application/json",
+              "ontology": "elizaos:ontology:code/python/debug_analysis",
+              "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
+              "payload": {
+                "@type": "type.googleapis.com/elizaos.mcp.InformResultPayload",
+                "task_status": "PARTIAL_SUCCESS", // Corresponds to TaskStatus enum
+                "result_summary": "Initial analysis of the Python IndexError (via gRPC task) indicates a likely out-of-bounds list access. Specific code and traceback are required.",
+                "result_details": {
+                  "analysis": "The reported IndexError in Python, especially when parsing log files, commonly arises from attempting to access a list element with an index that is outside the valid range. This can occur if log lines are split incorrectly, assumptions about the number of fields per log line are not consistently met, or loop conditions are flawed. To debug this, the user should verify list lengths before access, check array indexing logic within loops, and ensure that any string splitting or parsing logic robustly handles variations in log line formats.",
+                  "request_for_user": "To provide a specific fix for the IndexError, please ask the user (via Eddy) to provide the Python code snippet where the error occurs and the complete error traceback."
+                },
+                "artifacts": []
+              }
             }
           }
         }


### PR DESCRIPTION
This commit updates Eddy.json and Jules.json to simulate inter-agent communication using a conceptual gRPC framework. This replaces the earlier file-based queue simulation.

- Agent 'thought' processes now describe constructing Protobuf-like messages and making simulated gRPC calls to an 'AgentCommunicationService'.
- The 'simulated_grpc_call' field in messageExamples details these conceptual RPCs (service, method, target, request_message).
- Request_message payloads include an '@type' field to represent the conceptual Protobuf message type packed in 'google.protobuf.Any'.
- This change aligns with the .proto definitions for MCP messages and services that were conceptually defined as part of this task. (The .proto definitions themselves should be committed separately).